### PR TITLE
[Fix] Remove internal mesh faces during decompression

### DIFF
--- a/decompress.py
+++ b/decompress.py
@@ -24,7 +24,7 @@ The provided code under `__main__` can decompress the entire Breaking Bad
 import os
 import time
 import argparse
-import gpytoolbox
+from gpytoolbox.copyleft import mesh_boolean
 
 import numpy as np
 from tqdm import tqdm
@@ -83,7 +83,7 @@ def decompress_mesh(mesh_dir_full_path, save_dir):
             # Now we write the mesh ui, gi
             write_file_name = os.path.join(frac_save_path,
                                            "piece_" + str(i) + ".obj")
-            ui, gi = gpytoolbox.copyleft.mesh_boolean(ui,gi,ui,gi,boolean_type='union')
+            ui, gi = mesh_boolean(ui,gi,ui,gi,boolean_type='union')
             igl.write_triangle_mesh(write_file_name, ui, gi)
             num_fracs = num_fracs + 1
 

--- a/decompress.py
+++ b/decompress.py
@@ -24,6 +24,7 @@ The provided code under `__main__` can decompress the entire Breaking Bad
 import os
 import time
 import argparse
+import gpytoolbox
 
 import numpy as np
 from tqdm import tqdm
@@ -82,6 +83,7 @@ def decompress_mesh(mesh_dir_full_path, save_dir):
             # Now we write the mesh ui, gi
             write_file_name = os.path.join(frac_save_path,
                                            "piece_" + str(i) + ".obj")
+            ui, gi = gpytoolbox.copyleft.mesh_boolean(ui,gi,ui,gi,boolean_type='union')
             igl.write_triangle_mesh(write_file_name, ui, gi)
             num_fracs = num_fracs + 1
 

--- a/decompress.py
+++ b/decompress.py
@@ -80,11 +80,13 @@ def decompress_mesh(mesh_dir_full_path, save_dir):
                 continue
             ui, I, J, _ = igl.remove_duplicate_vertices(vi, fi, 1e-10)
             gi = J[fi]
+            ffi,_ = igl.resolve_duplicated_faces(gi)
+            nv,nf,IM,J = igl.remove_unreferenced(ui,ffi)
             # Now we write the mesh ui, gi
             write_file_name = os.path.join(frac_save_path,
                                            "piece_" + str(i) + ".obj")
-            ui, gi = mesh_boolean(ui,gi,ui,gi,boolean_type='union')
-            igl.write_triangle_mesh(write_file_name, ui, gi)
+            # ui, gi = mesh_boolean(ui,gi,ui,gi,boolean_type='union')
+            igl.write_triangle_mesh(write_file_name, nv, nf)
             num_fracs = num_fracs + 1
 
     return num_fracs


### PR DESCRIPTION
See [issue](https://github.com/Wuziyi616/multi_part_assembly/issues/6#issuecomment-1433133326). In our original data decompression code, the fracture meshes contain internal faces introduced by the fracture simulation algorithm. This is undesired, because there will be both surface and inner points in the sampled point clouds. The inner points are useless for shape assembly, and will cause errors in the evaluation metrics (some statistics shift). We fix it by removing the inner mesh faces during the decompression process, so that we don't need to re-generate the data.

**To use the inner-face-free version of data, you don't need to re-download data from the website. Instead, please remove the decompressed data, and re-run `decompress.py` to get the correct data!** We are re-running the benchmark results.